### PR TITLE
Add Variants which run in the Eff monad

### DIFF
--- a/src/Effectful/Resource.hs
+++ b/src/Effectful/Resource.hs
@@ -23,14 +23,14 @@ module Effectful.Resource
   , Key
   , InvalidKey(..)
   , manage
+  , manageEff
   , allocate
+  , allocateEff
   , free
   , freeAll
   , move
   , move_
   , defer
-  , manageEff
-  , allocateEff
   , deferEff
   ) where
 

--- a/src/Effectful/Resource.hs
+++ b/src/Effectful/Resource.hs
@@ -177,7 +177,7 @@ manage
   -> (a -> IO b) -- ^ The computation which releases the resource.
   -> Eff es a    -- ^ The acquired resource.
 manage create destroy =
-  fmap fst $ allocate create destroy
+  fst <$> allocate create destroy
 
 -- | Moves a resource to the specified region, yielding a new key for the resource.
 -- The old key is invalid after the movement.

--- a/src/Effectful/Resource.hs
+++ b/src/Effectful/Resource.hs
@@ -228,7 +228,7 @@ allocateEff
 allocateEff create destroy = do
   Resource region <- getStaticRep
   unsafeSeqUnliftIO $ \run ->
-    manageIO region (run create) (run . const (pure ()) . destroy)
+    manageIO region (run create) (run . void . destroy)
 
 -- | Allocates a resource in the current region which is automatically freed at
 -- the end of the region.


### PR DESCRIPTION
I quite like the idea of region based resources. I also love having fewer dependencies.
however i found the allocateEff of resourcet-effectful useful.
This PR adds Eff variants for all functions which mention IO.